### PR TITLE
Make alt_text and description_text fields optional

### DIFF
--- a/server/settings.py
+++ b/server/settings.py
@@ -64,7 +64,8 @@ KEYWORDS_ADD_MISSING_ON_PUBLISH = True
 SCHEMA = {
     'picture': {
         'headline': {'required': False},
-        'description_text': {'required': True},
+        'description_text': {'required': False, 'textarea': True},
+        'alt_text': {'required': False},
         'byline': {'required': False},
         'sign_off': {'required': False}
     },


### PR DESCRIPTION
### Reasons 

For the migration, we need the `description_text` and `alt_text` fields set as optional because in the imported articles those fields might not be filled in.