### PR TITLE
Set alt_text and description_text fields as optional

### DIFF
--- a/server/settings.py
+++ b/server/settings.py
@@ -60,6 +60,35 @@ PUBLISH_ASSOCIATED_ITEMS = True
 # storing published keywords in a CV
 KEYWORDS_ADD_MISSING_ON_PUBLISH = True
 
+# media required fields
+VALIDATOR_MEDIA_METADATA = {
+    "headline": {
+        "required": False,
+    },
+    "alt_text": {
+        "required": False,
+    },
+    "archive_description": {
+        "required": False,
+    },
+    "description_text": {
+        "required": False,
+        "textarea": True,
+    },
+    "copyrightholder": {
+        "required": False,
+    },
+    "byline": {
+        "required": False,
+    },
+    "usageterms": {
+        "required": False,
+    },
+    "copyrightnotice": {
+        "required": False,
+    },
+}
+
 # schema for images, video, audio
 SCHEMA = {
     'picture': {


### PR DESCRIPTION
It looks like this PR https://github.com/superdesk/superdesk-ewtn/commit/85b129f4705b8215043c5a1c4144c40e46cae729 didn't set those fields as optional.