### PR TITLE
Downgrading docker ubuntu image version

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive 
 


### PR DESCRIPTION
Downgrading docker ubuntu image version from 22.04. to 20.04 for compatibility with the version of superdesk we're using