### PR TITLE
Headline capitalizer macro

### DIFF
--- a/server/ewt/macros/__init__.py
+++ b/server/ewt/macros/__init__.py
@@ -1,2 +1,3 @@
 
 from . import set_default_template_metadata  # noqa
+from . import headline_capitalizer # noqa

--- a/server/ewt/macros/headline_capitalizer.py
+++ b/server/ewt/macros/headline_capitalizer.py
@@ -1,0 +1,69 @@
+import itertools
+import superdesk.editor_utils as editor_utils
+
+
+do_not_capitalize = "a an the and but for at by in to of".split()
+
+
+def capitalize(item, **kwargs):
+    """
+        Properly capitalize the headline per National Catholic Register conventions.
+        This approximates the Associated Press style guidelines (words with 4 or more letters should
+        be capitalized).  However, in practice, an implementation more consistent with the Register's conventions is
+        simply to have a whitelist of non-capitalized words, and everything else gets capitalized.
+    """
+
+    if item.get("headline", None):
+        old_headline = item["headline"]
+        capitalized_headline = capitalize_headline(item["headline"])
+        editor_utils.replace_text(item, "headline", old_headline, capitalized_headline)
+        item["headline"] = capitalized_headline
+
+    return item
+
+
+def capitalize_headline(headline):
+    words = []
+    splitters = []
+    word = ""
+    for char in headline:
+        if char in [' ', '-']:
+            splitters.append(char)
+            words.append(word)
+            word = ""
+        else:
+            word = word + char
+    words.append(word)
+
+    capitalized = []
+    for word in words:
+        if ''.join(filter(str.isalpha, word)) in do_not_capitalize:  # filtering non-alphabet chars from the word
+            capitalized.append(word)
+        else:
+            capitalized.append(uppercase_first_letter(word))
+
+    return "".join([item for sublist in itertools.zip_longest(capitalized, splitters, fillvalue="") for item in sublist])
+
+
+def uppercase_first_letter(word):
+    for i in range(len(word)):
+        '''
+            The input "word" may contain opening quotation marks, so ignore those / skip past them to find the first
+            non-quotation-mark character to capitalize.
+
+            \u2018 = left single quote
+            \u201C = left double quote
+        '''
+        if word[i] not in ['"', "'", "\u2018", "\u201C"]:
+            return word[0:i] + word[i].capitalize() + word[i + 1:]
+    return word
+
+
+name = "headline_capitalizer"
+label = "Capitalize Headline"
+order = 3
+shortcut = "c"
+callback = capitalize
+access_type = "frontend"
+action_type = "direct"
+replace_type = "editor_state"

--- a/server/ewt/macros/headline_capitalizer.py
+++ b/server/ewt/macros/headline_capitalizer.py
@@ -45,7 +45,9 @@ def capitalize_headline(headline):
         else:
             capitalized.append(uppercase_first_letter(word))
 
-    return "".join([item for sublist in itertools.zip_longest(capitalized, splitters, fillvalue="") for item in sublist])
+    zip_result = itertools.zip_longest(capitalized, splitters, fillvalue="")
+    ordered_bits = [item for sublist in zip_result for item in sublist]
+    return "".join(ordered_bits)
 
 
 def uppercase_first_letter(word):

--- a/server/ewt/macros/headline_capitalizer.py
+++ b/server/ewt/macros/headline_capitalizer.py
@@ -1,7 +1,9 @@
 import itertools
+import logging
 import superdesk.editor_utils as editor_utils
 
 
+logger = logging.getLogger(__name__)
 do_not_capitalize = "a an the and but for at by in to of".split()
 
 
@@ -18,6 +20,7 @@ def capitalize(item, **kwargs):
         capitalized_headline = capitalize_headline(item["headline"])
         editor_utils.replace_text(item, "headline", old_headline, capitalized_headline)
         item["headline"] = capitalized_headline
+        logger.info("Capitalized headline:\nFrom: [ %s ]\nTo:   [ %s ]", old_headline, capitalized_headline)
 
     return item
 

--- a/server/tests/macros/headline_capitalizer_test.py
+++ b/server/tests/macros/headline_capitalizer_test.py
@@ -1,0 +1,89 @@
+
+import unittest
+from ewt.macros import headline_capitalizer as macro
+
+
+class HeadlineCapitalizerTest(unittest.TestCase):
+
+    headlines = [
+        # Actual headlines from CNA & NCR
+        (
+            "Pope Francis: St. Andrew Kim Taegon teaches us ‘we must not give up’",
+            "Pope Francis: St. Andrew Kim Taegon Teaches Us ‘We Must Not Give Up’"
+        ), (
+            "Pope Francis: Pray that the Gospel can be freely shared in China",
+            "Pope Francis: Pray That the Gospel Can Be Freely Shared in China"
+        ), (
+            "80-year-old man tries to kill archbishop after Mass in cathedral in Mexico",
+            "80-Year-Old Man Tries to Kill Archbishop After Mass in Cathedral in Mexico"
+        ), (
+            "MiraVia maternity home brings hope and life to pregnant students in North Carolina",
+            "MiraVia Maternity Home Brings Hope and Life to Pregnant Students in North Carolina"
+        ), (
+            "Supreme Court Justice Gorsuch blasts COVID lockdowns, closing of churches",
+            "Supreme Court Justice Gorsuch Blasts COVID Lockdowns, Closing of Churches"
+        ), (
+            "PHOTOS: Thousands march in Italy’s national ‘Demonstration for Life’",
+            "PHOTOS: Thousands March in Italy’s National ‘Demonstration for Life’"
+        ), (
+            "Pope Francis approves beatification of priest martyred in World War II",
+            "Pope Francis Approves Beatification of Priest Martyred in World War II"
+        ), (
+            "Archdiocese in Mexico warns against attending SSPX Mass in newly built church",
+            "Archdiocese in Mexico Warns Against Attending SSPX Mass in Newly Built Church"
+        ), (
+            "Cardinal Ladaria: Truth about humanity and sexuality doesn’t change because of changes in ideology",
+            "Cardinal Ladaria: Truth About Humanity and Sexuality Doesn’t Change Because of Changes in Ideology"
+        ), (
+            "Pentecost Novena: Here’s how to pray the first novena",
+            "Pentecost Novena: Here’s How to Pray the First Novena"
+        ), (
+            "Report gives voice to Canada’s Indigenous Christians, highlights need for religious freedom",
+            "Report Gives Voice to Canada’s Indigenous Christians, Highlights Need for Religious Freedom"
+        ), (
+            "Blaze set at iconic Mexican church; Eucharist stolen from another",
+            "Blaze Set at Iconic Mexican Church; Eucharist Stolen From Another"
+        ), (
+            "House of saints: Visiting St. Thérèse of Lisieux’s home has inspired conversions",
+            "House of Saints: Visiting St. Thérèse of Lisieux’s Home Has Inspired Conversions"
+        ), (
+            "Texas becomes 18th state to ban sex changes for kids",
+            "Texas Becomes 18th State to Ban Sex Changes for Kids"
+        ),
+
+        # My own tests
+        (
+            "mother-in-law",
+            "Mother-in-Law"
+        ), (
+            " This headline has a leading space and a trailing dash-",
+            " This Headline Has a Leading Space and a Trailing Dash-"
+        ), (
+            "The current temperature is 42deg outside",
+            "The Current Temperature Is 42deg Outside"
+        ), (
+            'Someone said this is "a big deal"',
+            'Someone Said This Is "a Big Deal"'
+        ), (
+            'This headline is decidedly "not a big deal"',
+            'This Headline Is Decidedly "Not a Big Deal"'
+        ), (
+            "A tweet from @twitter_handle",
+            "A Tweet From @twitter_handle"
+        )
+    ]
+
+    def test_headline_capitalization(self):
+        for (uncapitalized, expected) in self.headlines:
+            item = {"headline": uncapitalized}
+            macro.callback(item)
+            self.assertEqual(expected, item["headline"])
+
+    def test_uppercase_first_letter_ignoring_quotes(self):
+        self.assertEqual("A", macro.uppercase_first_letter("a"))
+        self.assertEqual("Blah", macro.uppercase_first_letter("blah"))
+        self.assertEqual("'We", macro.uppercase_first_letter("'we"))
+        self.assertEqual("We're", macro.uppercase_first_letter("we're"))
+        self.assertEqual('"Who"', macro.uppercase_first_letter('"who"'))
+        self.assertEqual('\u2018Who', macro.uppercase_first_letter('\u2018who'))
+        self.assertEqual('\u201CWho', macro.uppercase_first_letter('\u201Cwho'))


### PR DESCRIPTION
Added a macro to automatically capitalize the headlines for articles we ingest from CNA, which use "sentence case", whereas NCRegister uses capitalization conventions similar to the AP style guide