### PR TITLE
Adding custom ingest logic for EWTN's Youtube feed

### DIFF
--- a/server/ewt/ingest/ewtn_youtube/__init__.py
+++ b/server/ewt/ingest/ewtn_youtube/__init__.py
@@ -1,0 +1,9 @@
+
+from superdesk.io.registry import register_feeding_service, register_feeding_service_parser
+
+from .rss import EWTNYoutubeFeedingService
+
+
+def init_app(_app):
+    register_feeding_service(EWTNYoutubeFeedingService)
+    register_feeding_service_parser(EWTNYoutubeFeedingService.NAME, None)

--- a/server/ewt/ingest/ewtn_youtube/rss.py
+++ b/server/ewt/ingest/ewtn_youtube/rss.py
@@ -1,0 +1,104 @@
+
+import re
+import lxml.html
+import lxml.etree
+
+from superdesk.io.feeding_services.rss import RSSFeedingService, generate_tag_from_url
+
+
+NSMAP = {
+    'media': 'http://search.yahoo.com/mrss/',
+    None: 'http://www.w3.org/2005/Atom',
+    'yt': 'http://www.youtube.com/xml/schemas/2015'
+}
+
+
+class EWTNYoutubeFeedingService(RSSFeedingService):
+    NAME = 'ewtn youtube rss'
+    label = 'EWTN Youtube RSS'
+
+    def _extract_image_links(self, rss_entry):
+        """NOOP, image will be associated via _create_item"""
+        return []
+
+    def _fetch_data(self):
+        """Store XML for later parsing."""
+        xml = super()._fetch_data()
+        self.tree = lxml.etree.fromstring(xml)
+        return xml
+
+    def _get_xml_item(self, data):
+        return next((
+            xml_item for xml_item in self.tree.findall('entry', NSMAP)
+            if xml_item.find('yt:videoId', NSMAP).text == data.yt_videoid
+        ), None)
+
+    def _create_item(self, data, field_aliases=None, source='source'):
+        item = super()._create_item(data, field_aliases, source)
+        item['headline'] = self._fix_text(item['headline'])
+        item['abstract'] = self._substring_before("----", item["abstract"]).strip()
+        item['abstract'] = self._substring_before("————", item["abstract"]).strip()
+        item['abstract'] = self._substring_before("Subscribe to EWTN’s YouTube Channel", item["abstract"]).strip()
+        if len(item['abstract']) == 0:
+            item['abstract'] = item['headline']
+        item['abstract'] = self._fix_text(item['abstract'])
+        item['body_html'] = self._fix_html(item["abstract"])
+        item['subject'] = [
+            {
+                "name": "Video",
+                "qcode": "video",
+                "scheme": "atype"
+            }
+        ]
+        xml_item = self._get_xml_item(data)
+        yt_video_link = xml_item.find("media:group", NSMAP).find("media:content", NSMAP).attrib["url"]
+        item['body_html'] = item['body_html'] + f"<p>Video link: {yt_video_link}</p>"
+        media_title = xml_item.find('media:group', NSMAP).find('media:title', NSMAP).text.strip()
+        thumbnail = xml_item.find("media:group", NSMAP).find("media:thumbnail", NSMAP)
+        rendition = {
+            'href': thumbnail.attrib['url'],
+            'width': int(thumbnail.attrib['width']),
+            'height': int(thumbnail.attrib['height']),
+            'mimetype': "image/jpeg",
+        }
+        item['associations'] = {
+            'featuremedia': {
+                'type': 'picture',
+                'guid': generate_tag_from_url(thumbnail.attrib['url']),
+                'headline': media_title,
+                'byline': '',
+                'creditline': '',
+                'description_text': '',
+                'firstcreated': item['versioncreated'],
+                'versioncreated': item['versioncreated'],
+                'renditions': {
+                    'original': rendition.copy(),
+                    'baseImage': rendition.copy(),
+                    'viewImage': rendition.copy(),
+                },
+            },
+        }
+        return item
+
+    def _substring_before(self, needle, haystack):
+        return haystack.split(needle)[0]
+
+    def _fix_text(self, text):
+        text = text \
+            .replace('--', '\u2014') \
+            .replace('<p><br />', '<p>')
+        text = re.sub(r'([\'"])([,.])', r'\2\1', text)  # put ., before closing quote
+        text = re.sub(r"'(.+?)'", '\u2018\\1\u2019', text)  # single quotes to smart
+        text = re.sub(r'"(.+?)"', '\u201C\\1\u201D', text)  # double quotes to smart
+        return text
+
+    def _fix_html(self, value):
+        html = lxml.html.fromstring(value)
+
+        for elem in html.iter():
+            if elem.text:
+                elem.text = self._fix_text(elem.text)
+            if elem.tail:
+                elem.tail = self._fix_text(elem.tail)
+
+        return lxml.html.tostring(html).decode()

--- a/server/settings.py
+++ b/server/settings.py
@@ -141,6 +141,7 @@ EDITOR['audio'] = EDITOR['video']
 INSTALLED_APPS = (
     'apps.languages',
     'ewt.ingest.cna',
+    'ewt.ingest.ewtn_youtube',
     'planning',
 )
 GEONAMES_USERNAME = env('GEONAMESUSERNAME')

--- a/server/tests/ingest/ewtn_youtube/rss.xml
+++ b/server/tests/ingest/ewtn_youtube/rss.xml
@@ -1,0 +1,647 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns:yt="http://www.youtube.com/xml/schemas/2015" xmlns:media="http://search.yahoo.com/mrss/"
+      xmlns="http://www.w3.org/2005/Atom">
+    <link rel="self" href="http://www.youtube.com/feeds/videos.xml?channel_id=UCijDos-LUTh9RQvSCMQqN6Q"/>
+    <id>yt:channel:</id>
+    <yt:channelId/>
+    <title>EWTN</title>
+    <link rel="alternate" href="https://www.youtube.com/channel/UCijDos-LUTh9RQvSCMQqN6Q"/>
+    <author>
+        <name>EWTN</name>
+        <uri>https://www.youtube.com/channel/UCijDos-LUTh9RQvSCMQqN6Q</uri>
+    </author>
+    <published>2006-11-23T11:42:56+00:00</published>
+    <entry>
+        <id>yt:video:2JELmDmKJlA</id>
+        <yt:videoId>2JELmDmKJlA</yt:videoId>
+        <yt:channelId>UCijDos-LUTh9RQvSCMQqN6Q</yt:channelId>
+        <title>THE CATHOLIC UNIVERSITY OF AMERICA: MASS OF THE HOLY SPIRIT - 2023-08-31</title>
+        <link rel="alternate" href="https://www.youtube.com/watch?v=2JELmDmKJlA"/>
+        <author>
+            <name>EWTN</name>
+            <uri>https://www.youtube.com/channel/UCijDos-LUTh9RQvSCMQqN6Q</uri>
+        </author>
+        <published>2023-09-01T12:08:55+00:00</published>
+        <updated>2023-09-01T12:37:46+00:00</updated>
+        <media:group>
+            <media:title>THE CATHOLIC UNIVERSITY OF AMERICA: MASS OF THE HOLY SPIRIT - 2023-08-31</media:title>
+            <media:content url="https://www.youtube.com/v/2JELmDmKJlA?version=3" type="application/x-shockwave-flash"
+                           width="640" height="390"/>
+            <media:thumbnail url="https://i3.ytimg.com/vi/2JELmDmKJlA/hqdefault.jpg" width="480" height="360"/>
+            <media:description>From the Basilica of the National Shrine of the Immaculate Conception, the traditional
+                Mass of the Holy Spirit marks the opening of the academic year at The Catholic University of America.
+                Subscribe to EWTN’s YouTube Channel: https://bit.ly/3hBbdVX EWTN Global Catholic Network, in its 40th
+                year, is the largest religious media network in the world and was founded by Mother Mary Angelica, PCPA.
+                The Daily Televised Mass is broadcast live 7 days a week at 7:00 a.m CST (watch it here:
+                https://www.ewtn.com/tv/watch-live). The Mass is uploaded to YouTube every day along with many other
+                programs. To contact EWTN, send an email to our Viewer Services team at viewer@ewtn.com or call
+                1-800-447-3986. To learn more about EWTN please visit https://www.ewtn.com Donate now -
+                https://bit.ly/3pBGjRU Follow us on Facebook - https://www.facebook.com/ewtnonline Follow us on Twitter:
+                https://twitter.com/EWTN Follow us on Instagram: https://www.instagram.com/ewtnmedia/
+            </media:description>
+            <media:community>
+                <media:starRating count="7" average="5.00" min="1" max="5"/>
+                <media:statistics views="334"/>
+            </media:community>
+        </media:group>
+    </entry>
+    <entry>
+        <id>yt:video:w9SBUR-yZVU</id>
+        <yt:videoId>w9SBUR-yZVU</yt:videoId>
+        <yt:channelId>UCijDos-LUTh9RQvSCMQqN6Q</yt:channelId>
+        <title>TOB Program Empowers Parents to be Primary Educators</title>
+        <link rel="alternate" href="https://www.youtube.com/watch?v=w9SBUR-yZVU"/>
+        <author>
+            <name>EWTN</name>
+            <uri>https://www.youtube.com/channel/UCijDos-LUTh9RQvSCMQqN6Q</uri>
+        </author>
+        <published>2023-09-01T12:00:48+00:00</published>
+        <updated>2023-09-01T12:00:49+00:00</updated>
+        <media:group>
+            <media:title>TOB Program Empowers Parents to be Primary Educators</media:title>
+            <media:content url="https://www.youtube.com/v/w9SBUR-yZVU?version=3" type="application/x-shockwave-flash"
+                           width="640" height="390"/>
+            <media:thumbnail url="https://i4.ytimg.com/vi/w9SBUR-yZVU/hqdefault.jpg" width="480" height="360"/>
+            <media:description>The TOB Parent School equips parents to reclaim their role as the first teachers of their
+                children. Founder Lindsay Caron explains the need for parents to share with their children the truth and
+                beauty of humanity and relationships. -------- EWTN Pro-Life Weekly with Prudence Robertson airs on EWTN
+                every Thursday night at 10 pm ET. It re-airs on Sundays at 10:30 am and Tuesdays at 1:30 pm. This TV
+                show seeks to inform and engage on life issues. It is produced by EWTN News https://www.ewtnnews.com
+                -------- Don't miss an episode of EWTN Pro-Life Weekly. Get updates here:
+                https://www.ewtn.com/tv/shows/ewtn-pro-life-weekly -------- Sign up today to receive the Pro-Life Weekly
+                newsletter: https://ewtn.com/prolife Subscribe to EWTN YouTube channel here:
+                https://www.youtube.com/user/EWTN -------- Follow EWTN Pro-Life Weekly on Social Media: Facebook:
+                https://www.facebook.com/EWTNProLife Twitter: https://twitter.com/EWTNProLife Instagram:
+                https://www.instagram.com/EWTNProLife/ ------------- You can support the EWTN News mission:
+                https://bit.ly/3qDR1qf
+            </media:description>
+            <media:community>
+                <media:starRating count="1" average="5.00" min="1" max="5"/>
+                <media:statistics views="60"/>
+            </media:community>
+        </media:group>
+    </entry>
+    <entry>
+        <id>yt:video:2H5_dgIkqOo</id>
+        <yt:videoId>2H5_dgIkqOo</yt:videoId>
+        <yt:channelId>UCijDos-LUTh9RQvSCMQqN6Q</yt:channelId>
+        <title>HOLY ROSARY AND DEVOTIONS WITH THE FRANCISCAN MISSIONARIES OF THE ETERNAL WORD - 2023-08-29</title>
+        <link rel="alternate" href="https://www.youtube.com/watch?v=2H5_dgIkqOo"/>
+        <author>
+            <name>EWTN</name>
+            <uri>https://www.youtube.com/channel/UCijDos-LUTh9RQvSCMQqN6Q</uri>
+        </author>
+        <published>2023-08-29T14:16:58+00:00</published>
+        <updated>2023-08-29T14:20:40+00:00</updated>
+        <media:group>
+            <media:title>HOLY ROSARY AND DEVOTIONS WITH THE FRANCISCAN MISSIONARIES OF THE ETERNAL WORD - 2023-08-29
+            </media:title>
+            <media:content url="https://www.youtube.com/v/2H5_dgIkqOo?version=3" type="application/x-shockwave-flash"
+                           width="640" height="390"/>
+            <media:thumbnail url="https://i3.ytimg.com/vi/2H5_dgIkqOo/hqdefault.jpg" width="480" height="360"/>
+            <media:description>Subscribe to EWTN’s YouTube Channel: https://bit.ly/3hBbdVX EWTN Global Catholic Network,
+                in its 40th year, is the largest religious media network in the world and was founded by Mother Mary
+                Angelica, PCPA. The Daily Televised Mass is broadcast live 7 days a week at 7:00 a.m CST (watch it here:
+                https://www.ewtn.com/tv/watch-live). The Mass is uploaded to YouTube every day along with many other
+                programs. To contact EWTN, send an email to our Viewer Services team at viewer@ewtn.com or call
+                1-800-447-3986. To learn more about EWTN please visit https://www.ewtn.com Donate now -
+                https://bit.ly/3pBGjRU Follow us on Facebook - https://www.facebook.com/ewtnonline Follow us on Twitter:
+                https://twitter.com/EWTN Follow us on Instagram: https://www.instagram.com/ewtnmedia/
+            </media:description>
+            <media:community>
+                <media:starRating count="14" average="5.00" min="1" max="5"/>
+                <media:statistics views="36"/>
+            </media:community>
+        </media:group>
+    </entry>
+    <entry>
+        <id>yt:video:jwycdXpI7ZY</id>
+        <yt:videoId>jwycdXpI7ZY</yt:videoId>
+        <yt:channelId>UCijDos-LUTh9RQvSCMQqN6Q</yt:channelId>
+        <title>Take 2 with Jerry &amp; Debbie - August 28, 2023 - Tell us Your Favorite Clean Joke for August 2023
+        </title>
+        <link rel="alternate" href="https://www.youtube.com/watch?v=jwycdXpI7ZY"/>
+        <author>
+            <name>EWTN</name>
+            <uri>https://www.youtube.com/channel/UCijDos-LUTh9RQvSCMQqN6Q</uri>
+        </author>
+        <published>2023-08-29T14:16:45+00:00</published>
+        <updated>2023-08-29T14:17:39+00:00</updated>
+        <media:group>
+            <media:title>Take 2 with Jerry &amp; Debbie - August 28, 2023 - Tell us Your Favorite Clean Joke for August
+                2023
+            </media:title>
+            <media:content url="https://www.youtube.com/v/jwycdXpI7ZY?version=3" type="application/x-shockwave-flash"
+                           width="640" height="390"/>
+            <media:thumbnail url="https://i3.ytimg.com/vi/jwycdXpI7ZY/hqdefault.jpg" width="480" height="360"/>
+            <media:description>🟢 Laughter is a huge part of living. We read in John 11:35 that “Jesus wept.” Being fully
+                human (as well as fully divine), we have to assume that he also laughed. Join the show and let us hear
+                your favorite clean joke, so we can all have a laugh in these challenging times in which we’re living.
+                833-288-3986🟥 ☎
+            </media:description>
+            <media:community>
+                <media:starRating count="0" average="0.00" min="1" max="5"/>
+                <media:statistics views="0"/>
+            </media:community>
+        </media:group>
+    </entry>
+    <entry>
+        <id>yt:video:42TWhw8Iv1Y</id>
+        <yt:videoId>42TWhw8Iv1Y</yt:videoId>
+        <yt:channelId>UCijDos-LUTh9RQvSCMQqN6Q</yt:channelId>
+        <title>Catholic Daily Mass - Daily TV Mass - August 29, 2023</title>
+        <link rel="alternate" href="https://www.youtube.com/watch?v=42TWhw8Iv1Y"/>
+        <author>
+            <name>EWTN</name>
+            <uri>https://www.youtube.com/channel/UCijDos-LUTh9RQvSCMQqN6Q</uri>
+        </author>
+        <published>2023-08-29T13:34:19+00:00</published>
+        <updated>2023-08-29T13:51:08+00:00</updated>
+        <media:group>
+            <media:title>Catholic Daily Mass - Daily TV Mass - August 29, 2023</media:title>
+            <media:content url="https://www.youtube.com/v/42TWhw8Iv1Y?version=3" type="application/x-shockwave-flash"
+                           width="640" height="390"/>
+            <media:thumbnail url="https://i1.ytimg.com/vi/42TWhw8Iv1Y/hqdefault.jpg" width="480" height="360"/>
+            <media:description>Starting at 8 a.m. ET on EWTN: Holy Mass and Rosary on Tuesday, August 29, 2023 - The
+                Memorial of the Passion of St. John the Baptist Tell us where you're watching from, and include your
+                intentions for Holy Mass. Act of spiritual communion -
+                https://www.ewtn.com/catholicism/devotions/act-of-spiritual-communion-339 For EWTN's full programming
+                schedule in your local time: http://bit.ly/EWTNtv #ewtn #Catholic #DailyMass #CatholicMass #Rosary
+                #Eucharist
+            </media:description>
+            <media:community>
+                <media:starRating count="0" average="0.00" min="1" max="5"/>
+                <media:statistics views="4114"/>
+            </media:community>
+        </media:group>
+    </entry>
+    <entry>
+        <id>yt:video:sFWdpO0PaN8</id>
+        <yt:videoId>sFWdpO0PaN8</yt:videoId>
+        <yt:channelId>UCijDos-LUTh9RQvSCMQqN6Q</yt:channelId>
+        <title>MOTHER ANGELICA LIVE CLASSICS - 1999-09-21 - ST. MATTHEW</title>
+        <link rel="alternate" href="https://www.youtube.com/watch?v=sFWdpO0PaN8"/>
+        <author>
+            <name>EWTN</name>
+            <uri>https://www.youtube.com/channel/UCijDos-LUTh9RQvSCMQqN6Q</uri>
+        </author>
+        <published>2023-08-29T13:05:52+00:00</published>
+        <updated>2023-08-29T13:34:38+00:00</updated>
+        <media:group>
+            <media:title>MOTHER ANGELICA LIVE CLASSICS - 1999-09-21 - ST. MATTHEW</media:title>
+            <media:content url="https://www.youtube.com/v/sFWdpO0PaN8?version=3" type="application/x-shockwave-flash"
+                           width="640" height="390"/>
+            <media:thumbnail url="https://i4.ytimg.com/vi/sFWdpO0PaN8/hqdefault.jpg" width="480" height="360"/>
+            <media:description>St. Matthew was a different kind of tax collector – he was a thief. Mother discusses his
+                life and how Our Lord continues to reach out to poor sinners like him. Subscribe to EWTN’s YouTube
+                Channel: https://bit.ly/3hBbdVX EWTN Global Catholic Network, in its 40th year, is the largest religious
+                media network in the world and was founded by Mother Mary Angelica, PCPA. The Daily Televised Mass is
+                broadcast live 7 days a week at 7:00 a.m CST (watch it here: https://www.ewtn.com/tv/watch-live). The
+                Mass is uploaded to YouTube every day along with many other programs. To contact EWTN, send an email to
+                our Viewer Services team at viewer@ewtn.com or call 1-800-447-3986. To learn more about EWTN please
+                visit https://www.ewtn.com Donate now - https://bit.ly/3pBGjRU Follow us on Facebook -
+                https://www.facebook.com/ewtnonline Follow us on Twitter: https://twitter.com/EWTN Follow us on
+                Instagram: https://www.instagram.com/ewtnmedia/
+            </media:description>
+            <media:community>
+                <media:starRating count="3" average="5.00" min="1" max="5"/>
+                <media:statistics views="58"/>
+            </media:community>
+        </media:group>
+    </entry>
+    <entry>
+        <id>yt:video:4Z2jEdG9AcU</id>
+        <yt:videoId>4Z2jEdG9AcU</yt:videoId>
+        <yt:channelId>UCijDos-LUTh9RQvSCMQqN6Q</yt:channelId>
+        <title>JOURNEY HOME - 2023-08-28 - DR. TORY BAUCUM</title>
+        <link rel="alternate" href="https://www.youtube.com/watch?v=4Z2jEdG9AcU"/>
+        <author>
+            <name>EWTN</name>
+            <uri>https://www.youtube.com/channel/UCijDos-LUTh9RQvSCMQqN6Q</uri>
+        </author>
+        <published>2023-08-29T01:00:01+00:00</published>
+        <updated>2023-08-29T01:00:02+00:00</updated>
+        <media:group>
+            <media:title>JOURNEY HOME - 2023-08-28 - DR. TORY BAUCUM</media:title>
+            <media:content url="https://www.youtube.com/v/4Z2jEdG9AcU?version=3" type="application/x-shockwave-flash"
+                           width="640" height="390"/>
+            <media:thumbnail url="https://i1.ytimg.com/vi/4Z2jEdG9AcU/hqdefault.jpg" width="480" height="360"/>
+            <media:description>JonMarc Grodi talks to former Episcopal priest and seminary professor Dr. Tory Baucum
+                about what led him to enter full communion with the Catholic Church. Subscribe to EWTN’s YouTube
+                Channel: https://bit.ly/3hBbdVX EWTN Global Catholic Network, in its 40th year, is the largest religious
+                media network in the world and was founded by Mother Mary Angelica, PCPA. The Daily Televised Mass is
+                broadcast live 7 days a week at 7:00 a.m CST (watch it here: https://www.ewtn.com/tv/watch-live). The
+                Mass is uploaded to YouTube every day along with many other programs. To contact EWTN, send an email to
+                our Viewer Services team at viewer@ewtn.com or call 1-800-447-3986. To learn more about EWTN please
+                visit https://www.ewtn.com Donate now - https://bit.ly/3pBGjRU Follow us on Facebook -
+                https://www.facebook.com/ewtnonline Follow us on Twitter: https://twitter.com/EWTN Follow us on
+                Instagram: https://www.instagram.com/ewtnmedia/
+            </media:description>
+            <media:community>
+                <media:starRating count="115" average="5.00" min="1" max="5"/>
+                <media:statistics views="2491"/>
+            </media:community>
+        </media:group>
+    </entry>
+    <entry>
+        <id>yt:video:mtD375YJC14</id>
+        <yt:videoId>mtD375YJC14</yt:videoId>
+        <yt:channelId>UCijDos-LUTh9RQvSCMQqN6Q</yt:channelId>
+        <title>Daily Readings and Homily - 2023-08-28 - Fr. John Paul</title>
+        <link rel="alternate" href="https://www.youtube.com/watch?v=mtD375YJC14"/>
+        <author>
+            <name>EWTN</name>
+            <uri>https://www.youtube.com/channel/UCijDos-LUTh9RQvSCMQqN6Q</uri>
+        </author>
+        <published>2023-08-29T00:00:31+00:00</published>
+        <updated>2023-08-29T00:00:32+00:00</updated>
+        <media:group>
+            <media:title>Daily Readings and Homily - 2023-08-28 - Fr. John Paul</media:title>
+            <media:content url="https://www.youtube.com/v/mtD375YJC14?version=3" type="application/x-shockwave-flash"
+                           width="640" height="390"/>
+            <media:thumbnail url="https://i2.ytimg.com/vi/mtD375YJC14/hqdefault.jpg" width="480" height="360"/>
+            <media:description>St. Augustine, Bishop, Doctor of the Church (Memorial) Subscribe to EWTN’s YouTube
+                Channel: https://bit.ly/3hBbdVX EWTN Global Catholic Network, in its 40th year, is the largest religious
+                media network in the world and was founded by Mother Mary Angelica, PCPA. The Daily Televised Mass is
+                broadcast live 7 days a week at 7:00 a.m CST (watch it here: https://www.ewtn.com/tv/watch-live). The
+                Mass is uploaded to YouTube every day along with many other programs. To contact EWTN, send an email to
+                our Viewer Services team at viewer@ewtn.com or call 1-800-447-3986. To learn more about EWTN please
+                visit https://www.ewtn.com Donate now - https://bit.ly/3pBGjRU Follow us on Facebook -
+                https://www.facebook.com/ewtnonline Follow us on Twitter: https://twitter.com/EWTN Follow us on
+                Instagram: https://www.instagram.com/ewtnmedia/
+            </media:description>
+            <media:community>
+                <media:starRating count="146" average="5.00" min="1" max="5"/>
+                <media:statistics views="1951"/>
+            </media:community>
+        </media:group>
+    </entry>
+    <entry>
+        <id>yt:video:j5WfSLDPII0</id>
+        <yt:videoId>j5WfSLDPII0</yt:videoId>
+        <yt:channelId>UCijDos-LUTh9RQvSCMQqN6Q</yt:channelId>
+        <title>Christian Finnish Politician Back in Court After Prosecutor Appeals Acquittal | EWTN News Nightly</title>
+        <link rel="alternate" href="https://www.youtube.com/watch?v=j5WfSLDPII0"/>
+        <author>
+            <name>EWTN</name>
+            <uri>https://www.youtube.com/channel/UCijDos-LUTh9RQvSCMQqN6Q</uri>
+        </author>
+        <published>2023-08-28T22:30:08+00:00</published>
+        <updated>2023-08-29T08:55:06+00:00</updated>
+        <media:group>
+            <media:title>Christian Finnish Politician Back in Court After Prosecutor Appeals Acquittal | EWTN News
+                Nightly
+            </media:title>
+            <media:content url="https://www.youtube.com/v/j5WfSLDPII0?version=3" type="application/x-shockwave-flash"
+                           width="640" height="390"/>
+            <media:thumbnail url="https://i3.ytimg.com/vi/j5WfSLDPII0/hqdefault.jpg" width="480" height="360"/>
+            <media:description>A former Finnish parliamentarian is back in court in Helsinki after a government
+                prosecutor appealed her 2022 acquittal. Former Minister of the Interior, Paivi Rasanen, was originally
+                prosecuted for hate speech stemming from her 2019 tweets that challenged her Church's sponsorship of the
+                2019 Helsinki Pride Parade. Rasanen, a Christian, will now face an appeals court in Finland as the
+                prosecutor looks to get the earlier acquittal overturned. Rasanen joins to share whether she could have
+                ever imagined the worldwide attention her tweet from the Book of Romans would garner and why she thinks
+                this case has sparked such attention and outrage. Rasanen gives us a brief synopsis of what is going on
+                legally. She explains what Finnish law says about free speech and given how clear the law is, why she
+                thinks the government continues its pursuit of a guilty verdict. Rasanen discusses whether she thinks
+                the appeals court will see this case the same way as the lower court. ------------ EWTN News Nightly
+                provides the latest news and analysis from a Catholic perspective. Join host Tracy Sabol, our Capitol
+                Hill, White House and Rome Correspondents, as well as many other diverse guests daily, to get the latest
+                from the U.S. and the Vatican on topics regarding our Catholic faith and interests. ------------- EWTN
+                News Nightly airs on EWTN weekdays at 6pm &amp; 9pm ET. ------------ Don't miss an episode of EWTN New
+                Nightly. Get updates here: https://www.ewtn.com/tv/shows/ewtn-news-nightly ------------- Sign up today
+                to receive the EWTN News Nightly newsletter: https://www.ewtn.com/enn ------------- Follow EWTN News
+                Nightly on Social Media: Facebook: https://www.facebook.com/ewtnnewsnightly Twitter:
+                https://twitter.com/EWTNNewsNightly Instagram: https://www.instagram.com/ewtnnewsnightly/ -------------
+                Subscribe to EWTN YouTube channel here: https://www.youtube.com/user/EWTN ------------- You can support
+                the EWTN News mission: https://bit.ly/3qDR1qf
+            </media:description>
+            <media:community>
+                <media:starRating count="27" average="5.00" min="1" max="5"/>
+                <media:statistics views="479"/>
+            </media:community>
+        </media:group>
+    </entry>
+    <entry>
+        <id>yt:video:OAVLTLRG0Hg</id>
+        <yt:videoId>OAVLTLRG0Hg</yt:videoId>
+        <yt:channelId>UCijDos-LUTh9RQvSCMQqN6Q</yt:channelId>
+        <title>Republicans Angry Over Abortion Language in the Pregnant Workers Fairness Act | EWTN News Nightly</title>
+        <link rel="alternate" href="https://www.youtube.com/watch?v=OAVLTLRG0Hg"/>
+        <author>
+            <name>EWTN</name>
+            <uri>https://www.youtube.com/channel/UCijDos-LUTh9RQvSCMQqN6Q</uri>
+        </author>
+        <published>2023-08-28T22:30:04+00:00</published>
+        <updated>2023-08-28T22:30:04+00:00</updated>
+        <media:group>
+            <media:title>Republicans Angry Over Abortion Language in the Pregnant Workers Fairness Act | EWTN News
+                Nightly
+            </media:title>
+            <media:content url="https://www.youtube.com/v/OAVLTLRG0Hg?version=3" type="application/x-shockwave-flash"
+                           width="640" height="390"/>
+            <media:thumbnail url="https://i4.ytimg.com/vi/OAVLTLRG0Hg/hqdefault.jpg" width="480" height="360"/>
+            <media:description>Republican lawmakers are angry over the inclusion of abortion language in proposed
+                federal workplace rules to protect pregnant workers. It threatens to derail a law that passed with
+                bipartisan support and sets up a possible legal fight. The Pregnant Workers Fairness Act allows
+                employers to give expectant mothers extra breaks, or use a different chair, so they can keep working
+                safely. But the Equal Employment Opportunity Commission, a federal agency, recently made abortion
+                eligible for workplace leave. Senator Bill Cassidy, one of the bill's chief sponsors says the EEOC is
+                going rogue. Now they want to say to employers that you have to give an accommodation to a woman who
+                wants to get an abortion - time off to get the abortion. During a floor debate last December, Democrat
+                co-sponsor Senator Bob Casey, a Catholic, made clear that abortion accommodations were not included.
+                Senator Casey said, "Under the Pregnant Workers Fairness Act, the Equal Employment Opportunity
+                Commission (EEOC) could not issue any regulation that requires abortion leave nor does the Act permit
+                the EEOC to require employers to provide abortion leave in violation of state law." However, Republican
+                Senator Thom Tillis, also a Catholic, says churches and other religious institutions could be hit with
+                lawsuits. Capitol Hill Correspondent, Erik Rosales reports. ------------ EWTN News Nightly provides the
+                latest news and analysis from a Catholic perspective. Join host Tracy Sabol, our Capitol Hill, White
+                House and Rome Correspondents, as well as many other diverse guests daily, to get the latest from the
+                U.S. and the Vatican on topics regarding our Catholic faith and interests. ------------- EWTN News
+                Nightly airs on EWTN weekdays at 6pm &amp; 9pm ET. ------------ Don't miss an episode of EWTN New
+                Nightly.
+                Get updates here: https://www.ewtn.com/tv/shows/ewtn-news-nightly ------------- Sign up today to receive
+                the EWTN News Nightly newsletter: https://www.ewtn.com/enn ------------- Follow EWTN News Nightly on
+                Social Media: Facebook: https://www.facebook.com/ewtnnewsnightly Twitter:
+                https://twitter.com/EWTNNewsNightly Instagram: https://www.instagram.com/ewtnnewsnightly/ -------------
+                Subscribe to EWTN YouTube channel here: https://www.youtube.com/user/EWTN ------------- You can support
+                the EWTN News mission: https://bit.ly/3qDR1qf
+            </media:description>
+            <media:community>
+                <media:starRating count="10" average="5.00" min="1" max="5"/>
+                <media:statistics views="373"/>
+            </media:community>
+        </media:group>
+    </entry>
+    <entry>
+        <id>yt:video:PEnN4cDPQiA</id>
+        <yt:videoId>PEnN4cDPQiA</yt:videoId>
+        <yt:channelId>UCijDos-LUTh9RQvSCMQqN6Q</yt:channelId>
+        <title>Pope Francis Addresses Russian Youth at Russia's Catholic Youth Day | EWTN News Nightly</title>
+        <link rel="alternate" href="https://www.youtube.com/watch?v=PEnN4cDPQiA"/>
+        <author>
+            <name>EWTN</name>
+            <uri>https://www.youtube.com/channel/UCijDos-LUTh9RQvSCMQqN6Q</uri>
+        </author>
+        <published>2023-08-28T22:30:04+00:00</published>
+        <updated>2023-08-29T02:47:12+00:00</updated>
+        <media:group>
+            <media:title>Pope Francis Addresses Russian Youth at Russia's Catholic Youth Day | EWTN News Nightly
+            </media:title>
+            <media:content url="https://www.youtube.com/v/PEnN4cDPQiA?version=3" type="application/x-shockwave-flash"
+                           width="640" height="390"/>
+            <media:thumbnail url="https://i1.ytimg.com/vi/PEnN4cDPQiA/hqdefault.jpg" width="480" height="360"/>
+            <media:description>The Holy Father urged young Russians to be "sowers of seeds of reconciliation and
+                artisans of peace." On the occasion of the Russian Catholic Youth Day over the weekend, Pope Francis
+                interacted remotely with about 400 boys and girls. Remembering the Lisbon World Youth Day motto, "Mary
+                got up and went in haste," he invited the youth "to have the courage to replace fears with dreams."
+                Organizer of the Russian Youth Day in St. Petersburg, Oksana Pimenova, joins to tell us more about what
+                Pope Francis said to young people and the highlights of this meeting. Pimenova shares more about the
+                event for Catholic youth in Russia, what some of the highlights were and how the Church is doing in
+                Russia. She will participate in the October Synod at the Vatican. Pimenova discusses what her role will
+                be and what expectations she has for this important meeting of the Universal Church. ------------ EWTN
+                News Nightly provides the latest news and analysis from a Catholic perspective. Join host Tracy Sabol,
+                our Capitol Hill, White House and Rome Correspondents, as well as many other diverse guests daily, to
+                get the latest from the U.S. and the Vatican on topics regarding our Catholic faith and interests.
+                ------------- EWTN News Nightly airs on EWTN weekdays at 6pm &amp; 9pm ET. ------------ Don't miss an
+                episode of EWTN New Nightly. Get updates here: https://www.ewtn.com/tv/shows/ewtn-news-nightly
+                ------------- Sign up today to receive the EWTN News Nightly newsletter: https://www.ewtn.com/enn
+                ------------- Follow EWTN News Nightly on Social Media: Facebook:
+                https://www.facebook.com/ewtnnewsnightly Twitter: https://twitter.com/EWTNNewsNightly Instagram:
+                https://www.instagram.com/ewtnnewsnightly/ ------------- Subscribe to EWTN YouTube channel here:
+                https://www.youtube.com/user/EWTN ------------- You can support the EWTN News mission:
+                https://bit.ly/3qDR1qf
+            </media:description>
+            <media:community>
+                <media:starRating count="61" average="5.00" min="1" max="5"/>
+                <media:statistics views="2468"/>
+            </media:community>
+        </media:group>
+    </entry>
+    <entry>
+        <id>yt:video:MHE8QwpMKoU</id>
+        <yt:videoId>MHE8QwpMKoU</yt:videoId>
+        <yt:channelId>UCijDos-LUTh9RQvSCMQqN6Q</yt:channelId>
+        <title>EWTN News Nightly | Monday, August 28, 2023</title>
+        <link rel="alternate" href="https://www.youtube.com/watch?v=MHE8QwpMKoU"/>
+        <author>
+            <name>EWTN</name>
+            <uri>https://www.youtube.com/channel/UCijDos-LUTh9RQvSCMQqN6Q</uri>
+        </author>
+        <published>2023-08-28T22:30:03+00:00</published>
+        <updated>2023-08-28T23:20:16+00:00</updated>
+        <media:group>
+            <media:title>EWTN News Nightly | Monday, August 28, 2023</media:title>
+            <media:content url="https://www.youtube.com/v/MHE8QwpMKoU?version=3" type="application/x-shockwave-flash"
+                           width="640" height="390"/>
+            <media:thumbnail url="https://i2.ytimg.com/vi/MHE8QwpMKoU/hqdefault.jpg" width="480" height="360"/>
+            <media:description>On "EWTN News Nightly" tonight: Republican lawmakers are angry over the inclusion of
+                abortion language in proposed federal workplace rules to protect pregnant workers. And the White House
+                is reacting to the horrific racist shooting in Jacksonville, Florida over the weekend that left three
+                Black people dead and a community grieving. On the occasion of the Russian Catholic Youth Day over the
+                weekend, Pope Francis interacted remotely with about 400 boys and girls. Organizer of the Russian Youth
+                Day in St. Petersburg, Oksana Pimenova, joins to tell us more about the highlights of this meeting.
+                Meanwhile, a former Finnish parliamentarian is back in court in Helsinki after a government prosecutor
+                appealed her 2022 acquittal. Former Minister of the Interior, Paivi Rasanen, joins to share whether she
+                could have ever imagined the worldwide attention her tweet from the Book of Romans would garner. Finally
+                this evening, a contemporary art gallery in Minnesota recently held what it described as a "demon
+                summoning session." A priest with the Companions of the Cross and host of "The Exorcist Files" podcast,
+                Fr. Carlos Martins, joins to share whether summoning a demon is ever a good idea. ------------ EWTN News
+                Nightly provides the latest news and analysis from a Catholic perspective. Join host Tracy Sabol, our
+                Capitol Hill, White House and Rome Correspondents, as well as many other diverse guests daily, to get
+                the latest from the U.S. and the Vatican on topics regarding our Catholic faith and interests.
+                ------------- EWTN News Nightly airs on EWTN weekdays at 6pm &amp; 9pm ET. ------------ Don't miss an
+                episode of EWTN New Nightly. Get updates here: https://www.ewtn.com/tv/shows/ewtn-news-nightly
+                ------------- Sign up today to receive the EWTN News Nightly newsletter: https://www.ewtn.com/enn
+                ------------- Follow EWTN News Nightly on Social Media: Facebook:
+                https://www.facebook.com/ewtnnewsnightly Twitter: https://twitter.com/EWTNNewsNightly Instagram:
+                https://www.instagram.com/ewtnnewsnightly/ ------------- Subscribe to EWTN YouTube channel here:
+                https://www.youtube.com/user/EWTN ------------- You can support the EWTN News mission:
+                https://bit.ly/3qDR1qf
+            </media:description>
+            <media:community>
+                <media:starRating count="160" average="5.00" min="1" max="5"/>
+                <media:statistics views="6130"/>
+            </media:community>
+        </media:group>
+    </entry>
+    <entry>
+        <id>yt:video:AV7Lj5W6ba8</id>
+        <yt:videoId>AV7Lj5W6ba8</yt:videoId>
+        <yt:channelId>UCijDos-LUTh9RQvSCMQqN6Q</yt:channelId>
+        <title>Biden Administration Says: ‘White supremacy has no place in America’ | EWTN News Nightly</title>
+        <link rel="alternate" href="https://www.youtube.com/watch?v=AV7Lj5W6ba8"/>
+        <author>
+            <name>EWTN</name>
+            <uri>https://www.youtube.com/channel/UCijDos-LUTh9RQvSCMQqN6Q</uri>
+        </author>
+        <published>2023-08-28T22:30:02+00:00</published>
+        <updated>2023-08-28T22:30:03+00:00</updated>
+        <media:group>
+            <media:title>Biden Administration Says: ‘White supremacy has no place in America’ | EWTN News Nightly
+            </media:title>
+            <media:content url="https://www.youtube.com/v/AV7Lj5W6ba8?version=3" type="application/x-shockwave-flash"
+                           width="640" height="390"/>
+            <media:thumbnail url="https://i2.ytimg.com/vi/AV7Lj5W6ba8/hqdefault.jpg" width="480" height="360"/>
+            <media:description>The White House is reacting to the horrific racist shooting in Jacksonville, Florida over
+                the weekend that left three Black people dead and a community grieving. The shooter, who had also posted
+                racist writings, killed himself. The racially-motivated murders happened as the White House observes the
+                60th anniversary of the “March on Washington,” on August 28th, 1963. And a trial date has been set for
+                former President Donald Trump in Washington, DC., while in Florida it’s all eyes on Hurricane Idalia.
+                White House Correspondent Owen Jensen reports. ------------ EWTN News Nightly provides the latest news
+                and analysis from a Catholic perspective. Join host Tracy Sabol, our Capitol Hill, White House and Rome
+                Correspondents, as well as many other diverse guests daily, to get the latest from the U.S. and the
+                Vatican on topics regarding our Catholic faith and interests. ------------- EWTN News Nightly airs on
+                EWTN weekdays at 6pm &amp; 9pm ET. ------------ Don't miss an episode of EWTN New Nightly. Get updates
+                here:
+                https://www.ewtn.com/tv/shows/ewtn-news-nightly ------------- Sign up today to receive the EWTN News
+                Nightly newsletter: https://www.ewtn.com/enn ------------- Follow EWTN News Nightly on Social Media:
+                Facebook: https://www.facebook.com/ewtnnewsnightly Twitter: https://twitter.com/EWTNNewsNightly
+                Instagram: https://www.instagram.com/ewtnnewsnightly/ ------------- Subscribe to EWTN YouTube channel
+                here: https://www.youtube.com/user/EWTN ------------- You can support the EWTN News mission:
+                https://bit.ly/3qDR1qf
+            </media:description>
+            <media:community>
+                <media:starRating count="8" average="5.00" min="1" max="5"/>
+                <media:statistics views="204"/>
+            </media:community>
+        </media:group>
+    </entry>
+    <entry>
+        <id>yt:video:2eOGpcKCd9E</id>
+        <yt:videoId>2eOGpcKCd9E</yt:videoId>
+        <yt:channelId>UCijDos-LUTh9RQvSCMQqN6Q</yt:channelId>
+        <title>Contemporary Art Gallery Holds "Demon Summoning Session" | EWTN News Nightly</title>
+        <link rel="alternate" href="https://www.youtube.com/watch?v=2eOGpcKCd9E"/>
+        <author>
+            <name>EWTN</name>
+            <uri>https://www.youtube.com/channel/UCijDos-LUTh9RQvSCMQqN6Q</uri>
+        </author>
+        <published>2023-08-28T22:30:00+00:00</published>
+        <updated>2023-08-28T22:30:07+00:00</updated>
+        <media:group>
+            <media:title>Contemporary Art Gallery Holds "Demon Summoning Session" | EWTN News Nightly</media:title>
+            <media:content url="https://www.youtube.com/v/2eOGpcKCd9E?version=3" type="application/x-shockwave-flash"
+                           width="640" height="390"/>
+            <media:thumbnail url="https://i3.ytimg.com/vi/2eOGpcKCd9E/hqdefault.jpg" width="480" height="360"/>
+            <media:description>A contemporary art gallery in Minnesota recently held what it described as a "demon
+                summoning session." The free event was part of the Walker Art Center's Plant Teachers Day. An author
+                made an exhibit on how to trap a demon. Part of it instructed people to text the word "summon" to a
+                phone number, and that way parents and children could communicate with the demon. A priest with the
+                Companions of the Cross and host of "The Exorcist Files" podcast, Fr. Carlos Martins, joins to share
+                whether summoning a demon is ever a good idea regardless of the intent. Fr. Carlos tells us whether he
+                is seeing other examples of this sort of attitude towards demons in the US these days. On another note,
+                he gives us an update on his podcast. "The Exorcist Files" has a 4.8 out of 5 rating with more than
+                3,400 reviews. Fr. Carlos fills us in on what comes next for the podcast and whether more episodes are
+                coming. ------------ EWTN News Nightly provides the latest news and analysis from a Catholic
+                perspective. Join host Tracy Sabol, our Capitol Hill, White House and Rome Correspondents, as well as
+                many other diverse guests daily, to get the latest from the U.S. and the Vatican on topics regarding our
+                Catholic faith and interests. ------------- EWTN News Nightly airs on EWTN weekdays at 6pm &amp; 9pm ET.
+                ------------ Don't miss an episode of EWTN New Nightly. Get updates here:
+                https://www.ewtn.com/tv/shows/ewtn-news-nightly ------------- Sign up today to receive the EWTN News
+                Nightly newsletter: https://www.ewtn.com/enn ------------- Follow EWTN News Nightly on Social Media:
+                Facebook: https://www.facebook.com/ewtnnewsnightly Twitter: https://twitter.com/EWTNNewsNightly
+                Instagram: https://www.instagram.com/ewtnnewsnightly/ ------------- Subscribe to EWTN YouTube channel
+                here: https://www.youtube.com/user/EWTN ------------- You can support the EWTN News mission:
+                https://bit.ly/3qDR1qf
+            </media:description>
+            <media:community>
+                <media:starRating count="112" average="5.00" min="1" max="5"/>
+                <media:statistics views="2179"/>
+            </media:community>
+        </media:group>
+    </entry>
+    <entry>
+        <id>yt:video:bLMvIkKtSW8</id>
+        <yt:videoId>bLMvIkKtSW8</yt:videoId>
+        <yt:channelId>UCijDos-LUTh9RQvSCMQqN6Q</yt:channelId>
+        <title>HOLY MASS FROM THE SHRINE OF OUR LADY OF CZESTOCHOWA - 2023-08-26</title>
+        <link rel="alternate" href="https://www.youtube.com/watch?v=bLMvIkKtSW8"/>
+        <author>
+            <name>EWTN</name>
+            <uri>https://www.youtube.com/channel/UCijDos-LUTh9RQvSCMQqN6Q</uri>
+        </author>
+        <published>2023-08-28T21:53:48+00:00</published>
+        <updated>2023-08-29T12:06:44+00:00</updated>
+        <media:group>
+            <media:title>HOLY MASS FROM THE SHRINE OF OUR LADY OF CZESTOCHOWA - 2023-08-26</media:title>
+            <media:content url="https://www.youtube.com/v/bLMvIkKtSW8?version=3" type="application/x-shockwave-flash"
+                           width="640" height="390"/>
+            <media:thumbnail url="https://i3.ytimg.com/vi/bLMvIkKtSW8/hqdefault.jpg" width="480" height="360"/>
+            <media:description>Subscribe to EWTN’s YouTube Channel: https://bit.ly/3hBbdVX EWTN Global Catholic Network,
+                in its 40th year, is the largest religious media network in the world and was founded by Mother Mary
+                Angelica, PCPA. The Daily Televised Mass is broadcast live 7 days a week at 7:00 a.m CST (watch it here:
+                https://www.ewtn.com/tv/watch-live). The Mass is uploaded to YouTube every day along with many other
+                programs. To contact EWTN, send an email to our Viewer Services team at viewer@ewtn.com or call
+                1-800-447-3986. To learn more about EWTN please visit https://www.ewtn.com Donate now -
+                https://bit.ly/3pBGjRU Follow us on Facebook - https://www.facebook.com/ewtnonline Follow us on Twitter:
+                https://twitter.com/EWTN Follow us on Instagram: https://www.instagram.com/ewtnmedia/
+            </media:description>
+            <media:community>
+                <media:starRating count="32" average="5.00" min="1" max="5"/>
+                <media:statistics views="690"/>
+            </media:community>
+        </media:group>
+    </entry>
+    <entry>
+        <id>yt:video:FvuRmLint2A</id>
+        <yt:videoId>FvuRmLint2A</yt:videoId>
+        <yt:channelId>UCijDos-LUTh9RQvSCMQqN6Q</yt:channelId>
+        <title>Catholic Daily Mass - Daily TV Mass - August 27, 2023</title>
+        <link rel="alternate" href="https://www.youtube.com/watch?v=FvuRmLint2A"/>
+        <author>
+            <name>EWTN</name>
+            <uri>https://www.youtube.com/channel/UCijDos-LUTh9RQvSCMQqN6Q</uri>
+        </author>
+        <published>2023-08-28T20:11:10+00:00</published>
+        <updated>2023-08-28T21:02:00+00:00</updated>
+        <media:group>
+            <media:title>Catholic Daily Mass - Daily TV Mass - August 27, 2023</media:title>
+            <media:content url="https://www.youtube.com/v/FvuRmLint2A?version=3" type="application/x-shockwave-flash"
+                           width="640" height="390"/>
+            <media:thumbnail url="https://i3.ytimg.com/vi/FvuRmLint2A/hqdefault.jpg" width="480" height="360"/>
+            <media:description>Twenty-First Sunday in Ordinary Time Today's Mass is celebrated by Father Matthew Mary
+                Readings: Is 22:19-23 Psalms 138:1-3, 6, 8 Rom 11:33-36 Mt 16:13-20 EWTN Global Catholic Network, in its
+                40th year, is the largest religious Catholic media network in the world and was founded by Mother Mary
+                Angelica, PCPA . The Daily Televised Mass is broadcast live 7 days a week at 7:00a.m (CST)
+                https://www.ewtn.com/catholicism/dail... and the mass is uploaded to YouTube everyday along with many
+                other programs. If you would like to contact EWTN, you can send an email to our Viewer Services team
+                viewer@ewtn.com or call 1-800-447-3986.@@@@ To learn more about EWTN please visit https://www.ewtn.com
+                Donate now - https://bit.ly/3pBGjRU Follow us on Facebook - https://www.facebook.com/ewtnonline Follow
+                us on Twitter: https://twitter.com/EWTN Follow us on Instagram: https://www.instagram.com/ewtnmedia/
+                #ewtn #Catholic #dailytelevisedmass #adailymass #CatholicMass #EWTN #Catholic #DailyMass #CatholicMass
+                #Rosary #Eucharist
+            </media:description>
+            <media:community>
+                <media:starRating count="0" average="0.00" min="1" max="5"/>
+                <media:statistics views="809"/>
+            </media:community>
+        </media:group>
+    </entry>
+    <entry>
+        <id>yt:video:K6TchJIE-UU</id>
+        <yt:videoId>K6TchJIE-UU</yt:videoId>
+        <yt:channelId>UCijDos-LUTh9RQvSCMQqN6Q</yt:channelId>
+        <title>Open Line, Monday w/ Fr. John Trigilio - August 28 , 2023</title>
+        <link rel="alternate" href="https://www.youtube.com/watch?v=K6TchJIE-UU"/>
+        <author>
+            <name>EWTN</name>
+            <uri>https://www.youtube.com/channel/UCijDos-LUTh9RQvSCMQqN6Q</uri>
+        </author>
+        <published>2023-08-28T19:58:59+00:00</published>
+        <updated>2023-08-28T23:40:05+00:00</updated>
+        <media:group>
+            <media:title>Open Line, Monday w/ Fr. John Trigilio - August 28 , 2023</media:title>
+            <media:content url="https://www.youtube.com/v/K6TchJIE-UU?version=3" type="application/x-shockwave-flash"
+                           width="640" height="390"/>
+            <media:thumbnail url="https://i4.ytimg.com/vi/K6TchJIE-UU/hqdefault.jpg" width="480" height="360"/>
+            <media:description>Fr. John Trigilio helps you find out how to better defend your faith! Call - 1- 833-288-
+                EWTN (3986) or 205-271-2985
+            </media:description>
+            <media:community>
+                <media:starRating count="0" average="0.00" min="1" max="5"/>
+                <media:statistics views="738"/>
+            </media:community>
+        </media:group>
+    </entry>
+</feed>

--- a/server/tests/ingest/ewtn_youtube/rss_test.py
+++ b/server/tests/ingest/ewtn_youtube/rss_test.py
@@ -43,7 +43,8 @@ class EWNTYoutube_RSSTestCase(unittest.TestCase):
         featured = item['associations']['featuremedia']
         self.assertEqual('tag:i3.ytimg.com:vi:2JELmDmKJlA:hqdefault.jpg', featured['guid'])
         # self.assertIn('Credit: Christine Rousselle/CNA', featured['description_text'])
-        self.assertEqual('THE CATHOLIC UNIVERSITY OF AMERICA: MASS OF THE HOLY SPIRIT - 2023-08-31', featured['headline'])
+        self.assertEqual('THE CATHOLIC UNIVERSITY OF AMERICA: MASS OF THE HOLY SPIRIT - 2023-08-31',
+                         featured['headline'])
         self.assertEqual('', featured['creditline'])
         self.assertEqual('', featured['byline'])
         self.assertEqual(item['versioncreated'], featured['versioncreated'])

--- a/server/tests/ingest/ewtn_youtube/rss_test.py
+++ b/server/tests/ingest/ewtn_youtube/rss_test.py
@@ -1,0 +1,59 @@
+
+import os
+import unittest
+import feedparser
+
+from lxml import etree
+from datetime import datetime
+from ewt.ingest.ewtn_youtube import EWTNYoutubeFeedingService
+
+
+with open(os.path.join(os.path.dirname(__file__), 'rss.xml'), encoding="utf-8") as f:
+    xml = f.read()
+
+
+NSMAP = {
+    'media': 'http://search.yahoo.com/mrss/',
+    None: 'http://www.w3.org/2005/Atom',
+    'yt': 'http://www.youtube.com/xml/schemas/2015'
+}
+
+
+class EWNTYoutube_RSSTestCase(unittest.TestCase):
+
+    def get_item(self, index=0):
+        data = feedparser.parse(xml)
+        service = EWTNYoutubeFeedingService()
+        service.tree = etree.fromstring(xml.encode())
+        item = service._create_item(data.entries[index])
+        return item
+
+    def test_parse_entry(self):
+        item = self.get_item()
+
+        self.assertIn("From the Basilica of the National Shrine of the Immaculate Conception", item['abstract'])
+        self.assertNotIn("Subscribe to EWTN’s YouTube Channel", item['abstract'])
+        self.assertIn("From the Basilica of the National Shrine of the Immaculate Conception", item['body_html'])
+        self.assertNotIn("Subscribe to EWTN’s YouTube Channel", item['body_html'])
+        self.assertEqual('EWTN', item['byline'])
+
+        self.assertEqual(datetime(2023, 9, 1, 12, 8, 55), item['firstcreated'])
+        self.assertEqual(datetime(2023, 9, 1, 12, 37, 46), item['versioncreated'])
+
+        featured = item['associations']['featuremedia']
+        self.assertEqual('tag:i3.ytimg.com:vi:2JELmDmKJlA:hqdefault.jpg', featured['guid'])
+        # self.assertIn('Credit: Christine Rousselle/CNA', featured['description_text'])
+        self.assertEqual('THE CATHOLIC UNIVERSITY OF AMERICA: MASS OF THE HOLY SPIRIT - 2023-08-31', featured['headline'])
+        self.assertEqual('', featured['creditline'])
+        self.assertEqual('', featured['byline'])
+        self.assertEqual(item['versioncreated'], featured['versioncreated'])
+        self.assertEqual(item['versioncreated'], featured['firstcreated'])
+        rend = featured['renditions']['baseImage']
+        self.assertEqual('https://i3.ytimg.com/vi/2JELmDmKJlA/hqdefault.jpg', rend['href'])
+
+    def test_fix_html(self):
+        service = EWTNYoutubeFeedingService()
+        self.assertEqual('<a href="--">&#8212;</a>', service._fix_html('<a href="--">--</a>'))
+        self.assertEqual("<a href=\"--\">&#8216;foo.&#8217;</a>", service._fix_html("<a href='--'>'foo'.</a>"))
+        self.assertEqual('<a href="--">&#8220;foo,&#8221;</a>', service._fix_html('<a href="--">"foo",</a>'))
+        self.assertEqual('<p>foo<br>&#8212;</p>', service._fix_html('<p>foo<br>--</p>'))


### PR DESCRIPTION
We have a desire to ingest videos into Superdesk from a playlist in EWTN's Youtube channel.  Please review my changes, and approve the pull request if everything looks okay.

Note that I largely based my new code on the existing ingest logic that was set up for NCRegister to be able to ingest articles from Catholic News Agency.

Let me know if you have any questions or concerns.  Thanks!